### PR TITLE
Update datamatrix.py

### DIFF
--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -16,7 +16,7 @@ from .utils import export
 svg_template = \
     '<?xml version="1.0" encoding="utf-8" ?>' \
     '<svg baseProfile="tiny" version="1.2" ' \
-    'viewBox="0 0 {height} {width}" ' \
+    'viewBox="0 0 {width} {height}" ' \
     'style="background-color:{bg}" ' \
     'xmlns="http://www.w3.org/2000/svg" ' \
     'xmlns:ev="http://www.w3.org/2001/xml-events" ' \


### PR DESCRIPTION
In `svg_template`, the `viewBox` width and height order was inverted.
Regarding the specification, the parameter's order is: min-x, min-y, width and height.
https://www.w3.org/TR/SVG2/coords.html#ViewBoxAttribute