### PR TITLE
Generate closed shapes, add ability to define SVG render size

### DIFF
--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -17,7 +17,7 @@ from .utils import export
 svg_rects_template = \
     '<?xml version="1.0" encoding="utf-8" ?>' \
     '<svg baseProfile="tiny" version="1.2" ' \
-    'viewBox="{x0} {y0} {vbx_width} {vbx_height}" ' \
+    'viewBox="{x0} {y0} {vbox_width} {vbox_height}" ' \
     'width="{width}mm" height="{height}mm" ' \
     'style="background-color:{bg}" ' \
     'xmlns="http://www.w3.org/2000/svg" ' \

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -85,9 +85,9 @@ class DataMatrix():
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym:
-                    yield f"<rect width='1' height='1' x='{i+1}' y='{j+1}' fill='{fg}' stroke='{fg}'>\n"
+                    yield f"\n<rect width='1' height='1' x='{i+1}' y='{j+1}' fill='{fg}' stroke='{fg}' />"
                 else:
-                    yield f"<rect width='1' height='1' x='{i+1}' y='{j+1}' fill='{bg}' stroke='{bg}'>\n"
+                    yield f"\n<rect width='1' height='1' x='{i+1}' y='{j+1}' fill='{bg}' stroke='{bg}' />"
 
     def svg(self, fg='#000', bg='#FFF', margin=1):
         """

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -13,10 +13,11 @@ __all__ = []
 
 from .utils import export
 
-svg_template = \
+# Template for generating closed-shape SVGs, for use with LightBurn and other etching software.
+svg_rects_template = \
     '<?xml version="1.0" encoding="utf-8" ?>' \
     '<svg baseProfile="tiny" version="1.2" ' \
-    'viewBox="{x0} {y0} {width} {height}" ' \
+    'viewBox="{x0} {y0} {vbx_width} {vbx_height}" ' \
     'width="{width}mm" height="{height}mm" ' \
     'style="background-color:{bg}" ' \
     'xmlns="http://www.w3.org/2000/svg" ' \
@@ -39,7 +40,8 @@ class DataMatrix():
     """
 
     def __init__(self, msg, rect=False,
-                 codecs=['ascii', 'C40', 'text', 'X12', 'edifact']):
+                 codecs=['ascii', 'C40', 'text', 'X12', 'edifact']:
+                     
         self.message = msg
         self.rectangular = rect
         for codec in codecs:
@@ -56,28 +58,6 @@ class DataMatrix():
     def _repr_svg_(self):
         return self.svg(bg='#000', fg='#FFF')
 
-    def _svg_path_iterator(self):
-        mat = self.matrix
-        w = len(mat[0])
-
-        for line in mat:
-            i = 0
-            while i < w:
-                color = line[i]
-                i0 = i
-                while i < w and line[i] == color:
-                    i = i + 1
-
-                length = i - i0
-                if color == 1:
-                    yield 'h'
-                    yield str(length)
-                else:
-                    yield 'm'
-                    yield f'{length},0'
-            yield 'm'
-            yield f'{-w},1'
-
     def _svg_rect_iterator(self,fg,bg):
         mat = self.matrix
         w = len(mat[0])
@@ -85,12 +65,10 @@ class DataMatrix():
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym==1:
-                    #yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{fg}' stroke='{fg}' />"
                     yield f"\n<rect width='2' height='2' x='{2*j+1}' y='{2*i+1}' fill='{fg}' />"
-                #else:
-                #    yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{bg}' stroke='{bg}' />"
 
-    def svg(self, fg='#000', bg='#FFF', margin=1):
+
+    def svg(self, fg='#000', bg='#FFF', margin=1, gen_rects=False, size="auto":
         """
         SVG of datamatrix.
 
@@ -100,8 +78,9 @@ class DataMatrix():
 
         Use the margin attribute to set the margin in units, defaults to 1.
         """
-        #cmds = ''.join(self._svg_path_iterator())
+        
         rects = ''.join(self._svg_rect_iterator(fg,bg))
+
         
         mat = self.matrix
         height = len(mat)
@@ -110,14 +89,23 @@ class DataMatrix():
         y0 = 1
 
         # margin is handled by adjusting the viewBox:
-        height += margin * 2
-        width += margin * 2
+        vbox_height += margin * 2
+        vbox_width += margin * 2
         x0 -= margin
         y0 -= margin
 
-        return svg_template.format(fg=fg, bg=bg, rects=rects,
-                                   x0=x0, y0=y0, height=2*height, width=2*width)
-
+        if size=="auto":
+            height = vbox_height
+            width = vbox_width
+        else:
+            width = size[0]
+            height = size[1]
+            
+        return svg_rects_template.format(fg=fg, bg=bg, rects=rects,
+                                x0=x0, y0=y0, 
+                                vbox_height=2*vbox_height, vbox_width=2*width,
+                                height=height, width=width)
+        
     @property
     def matrix(self):
         """

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -23,7 +23,7 @@ svg_rects_template = \
     'xmlns="http://www.w3.org/2000/svg" ' \
     'xmlns:ev="http://www.w3.org/2001/xml-events" ' \
     'xmlns:xlink="http://www.w3.org/1999/xlink"' \
-    'transform="scale({x_scale,y_scale} >' \
+    'transform="scale({x_scale},{y_scale}) >' \
     '{rects}' \
     '</svg>'
 

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -84,11 +84,16 @@ class DataMatrix():
         mat = self.matrix
         height = len(mat)
         width = len(mat[0])
+        vbox_height = (height+margin*2)*2
+        vbox_width = (width+margin*2)*2
+        if size:
+            height = size[1]
+            width = size[0]
         
         return svg_rects_template.format(fg=fg, bg=bg, rects=rects,
-                                vbox_width = (width+margin*2)*2,
-                                vbox_height = (height+margin*2)*2,
-                                height=2*height, width=2*width)
+                                vbox_width = vbox_width,
+                                vbox_height = vbox_height,
+                                height=height, width=width)
         
     @property
     def matrix(self):

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -22,8 +22,8 @@ svg_template = \
     'xmlns="http://www.w3.org/2000/svg" ' \
     'xmlns:ev="http://www.w3.org/2001/xml-events" ' \
     'xmlns:xlink="http://www.w3.org/1999/xlink">' \
-    '<path d="M1,1.5 {path_cmds}" ' \
-    'stroke="{fg}" stroke-width="1"/></svg>'
+    '{rects}' \
+    '</svg>'
 
 
 @export
@@ -78,6 +78,17 @@ class DataMatrix():
             yield 'm'
             yield f'{-w},1'
 
+    def _svg_rect_iterator(self,fg,bg):
+        mat = self.matrix
+        w = len(mat[0])
+
+        for i,line in enumerate(mat):    
+            for j,sym in enumerate(line):
+                if sym:
+                    yield f"<rect width=1 height=1 x={i+1} y={j+1} fill='{fg}' stroke='{fg}'>"
+                else:
+                    yield f"<rect width=1 height=1 x={i+1} y={j+1} fill='{bg}' stroke='{bg}'>"
+
     def svg(self, fg='#000', bg='#FFF', margin=1):
         """
         SVG of datamatrix.
@@ -88,7 +99,9 @@ class DataMatrix():
 
         Use the margin attribute to set the margin in units, defaults to 1.
         """
-        cmds = ''.join(self._svg_path_iterator())
+        #cmds = ''.join(self._svg_path_iterator())
+        rects = ''.join(self._svg_rect_iterator(fg,bg))
+        
         mat = self.matrix
         height = len(mat)
         width = len(mat[0])
@@ -101,7 +114,7 @@ class DataMatrix():
         x0 -= margin
         y0 -= margin
 
-        return svg_template.format(fg=fg, bg=bg, path_cmds=cmds,
+        return svg_template.format(fg=fg, bg=bg, rects=rects,
                                    x0=x0, y0=y0, height=height, width=width)
 
     @property

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -85,7 +85,8 @@ class DataMatrix():
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym==1:
-                    yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{fg}' stroke='{fg}' />"
+                    #yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{fg}' stroke='{fg}' />"
+                    yield f"\n<rect x='{j+1}' y='{i+1}' fill='{fg}' />"
                 #else:
                 #    yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{bg}' stroke='{bg}' />"
 

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -89,8 +89,8 @@ class DataMatrix():
         y0 = 1
 
         # margin is handled by adjusting the viewBox:
-        vbox_height += margin * 2
-        vbox_width += margin * 2
+        vbox_height = height + margin * 2
+        vbox_width = height + margin * 2
         x0 -= margin
         y0 -= margin
 

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -85,9 +85,9 @@ class DataMatrix():
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym:
-                    yield f"<rect width=1 height=1 x={i+1} y={j+1} fill='{fg}' stroke='{fg}'>"
+                    yield f"<rect width=1 height=1 x={i+1} y={j+1} fill='{fg}' stroke='{fg}'>\n"
                 else:
-                    yield f"<rect width=1 height=1 x={i+1} y={j+1} fill='{bg}' stroke='{bg}'>"
+                    yield f"<rect width=1 height=1 x={i+1} y={j+1} fill='{bg}' stroke='{bg}'>\n"
 
     def svg(self, fg='#000', bg='#FFF', margin=1):
         """

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -84,10 +84,10 @@ class DataMatrix():
 
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
-                if sym:
+                if sym==1:
                     yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{fg}' stroke='{fg}' />"
-                else:
-                    yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{bg}' stroke='{bg}' />"
+                #else:
+                #    yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{bg}' stroke='{bg}' />"
 
     def svg(self, fg='#000', bg='#FFF', margin=1):
         """

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -17,13 +17,12 @@ from .utils import export
 svg_rects_template = \
     '<?xml version="1.0" encoding="utf-8" ?>' \
     '<svg baseProfile="tiny" version="1.2" ' \
-    'viewBox="{x0} {y0} {width} {height}" ' \
+    'viewBox="0 0 {vbox_width} {vbox_height}" ' \
     'width="{width}mm" height="{height}mm" ' \
     'style="background-color:{bg}" ' \
     'xmlns="http://www.w3.org/2000/svg" ' \
     'xmlns:ev="http://www.w3.org/2001/xml-events" ' \
-    'xmlns:xlink="http://www.w3.org/1999/xlink" ' \
-    'transform="scale({x_scale},{y_scale})">' \
+    'xmlns:xlink="http://www.w3.org/1999/xlink" >' \
     '{rects}' \
     '</svg>'
 
@@ -59,14 +58,14 @@ class DataMatrix():
     def _repr_svg_(self):
         return self.svg(bg='#000', fg='#FFF')
 
-    def _svg_rect_iterator(self,fg,bg):
+    def _svg_rect_iterator(self,fg,bg,margin):
         mat = self.matrix
         w = len(mat[0])
 
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym==1:
-                    yield f"\n<rect width='2' height='2' x='{2*j+1}' y='{2*i+1}' fill='{fg}' />"
+                    yield f"\n<rect width='2' height='2' x='{2*(j+margin)}' y='{2*(i+margin)}' fill='{fg}' />"
 
 
     def svg(self, fg='#000', bg='#FFF', margin=1, size=None):
@@ -80,35 +79,16 @@ class DataMatrix():
         Use the margin attribute to set the margin in units, defaults to 1.
         """
         
-        rects = ''.join(self._svg_rect_iterator(fg,bg))
+        rects = ''.join(self._svg_rect_iterator(fg,bg,margin))
 
-        
         mat = self.matrix
         height = len(mat)
         width = len(mat[0])
-        x0 = 1
-        y0 = 1
-
-        # margin is handled by adjusting the viewBox:
-        vbox_height = height + margin * 2
-        vbox_width = width + margin * 2
-        x0 -= margin
-        y0 -= margin
-
-        if size=="auto":
-            height = vbox_height
-            width = vbox_width
-        else:
-            output_width = size[0]
-            output_height = size[1]
-
-        x_scale = output_width / width
-        y_scale = output_height / height
         
         return svg_rects_template.format(fg=fg, bg=bg, rects=rects,
-                                x0=x0, y0=y0, 
-                                height=2*height, width=2*width,
-                                x_scale=x_scale, y_scale=y_scale)
+                                vbox_width = (width+margin)*2,
+                                vbox_height = (height+margin)*2,
+                                height=2*height, width=2*width)
         
     @property
     def matrix(self):

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -85,9 +85,9 @@ class DataMatrix():
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym:
-                    yield f"\n<rect width='1' height='1' x='{i+1}' y='{j+1}' fill='{fg}' stroke='{fg}' />"
+                    yield f"\n<rect width='1' height='1' x='{j}' y='{i}' fill='{fg}' stroke='{fg}' />"
                 else:
-                    yield f"\n<rect width='1' height='1' x='{i+1}' y='{j+1}' fill='{bg}' stroke='{bg}' />"
+                    yield f"\n<rect width='1' height='1' x='{j}' y='{i}' fill='{bg}' stroke='{bg}' />"
 
     def svg(self, fg='#000', bg='#FFF', margin=1):
         """

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -40,7 +40,7 @@ class DataMatrix():
     """
 
     def __init__(self, msg, rect=False,
-                 codecs=['ascii', 'C40', 'text', 'X12', 'edifact']:
+                 codecs=['ascii', 'C40', 'text', 'X12', 'edifact']):
                      
         self.message = msg
         self.rectangular = rect

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -86,7 +86,7 @@ class DataMatrix():
             for j,sym in enumerate(line):
                 if sym==1:
                     #yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{fg}' stroke='{fg}' />"
-                    yield f"\n<rect x='{j+1}' y='{i+1}' fill='{fg}' />"
+                    yield f"\n<rect width='2' height='2' x='{2*j+1}' y='{2*i+1}' fill='{fg}' />"
                 #else:
                 #    yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{bg}' stroke='{bg}' />"
 

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -116,7 +116,7 @@ class DataMatrix():
         y0 -= margin
 
         return svg_template.format(fg=fg, bg=bg, rects=rects,
-                                   x0=x0, y0=y0, height=height, width=width)
+                                   x0=x0, y0=y0, height=2*height, width=2*width)
 
     @property
     def matrix(self):

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -85,9 +85,9 @@ class DataMatrix():
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym:
-                    yield f"<rect width=1 height=1 x='{i+1}' y='{j+1}' fill='{fg}' stroke='{fg}'>\n"
+                    yield f"<rect width='1' height='1' x='{i+1}' y='{j+1}' fill='{fg}' stroke='{fg}'>\n"
                 else:
-                    yield f"<rect width=1 height=1 x='{i+1}' y='{j+1}' fill='{bg}' stroke='{bg}'>\n"
+                    yield f"<rect width='1' height='1' x='{i+1}' y='{j+1}' fill='{bg}' stroke='{bg}'>\n"
 
     def svg(self, fg='#000', bg='#FFF', margin=1):
         """

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -102,8 +102,8 @@ class DataMatrix():
             output_width = size[0]
             output_height = size[1]
 
-        x_scale = output_width / width.
-        y_scale = output_height / height.
+        x_scale = output_width / width
+        y_scale = output_height / height
         
         return svg_rects_template.format(fg=fg, bg=bg, rects=rects,
                                 x0=x0, y0=y0, 

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -68,7 +68,7 @@ class DataMatrix():
                     yield f"\n<rect width='2' height='2' x='{2*j+1}' y='{2*i+1}' fill='{fg}' />"
 
 
-    def svg(self, fg='#000', bg='#FFF', margin=1, gen_rects=False, size="auto":
+    def svg(self, fg='#000', bg='#FFF', margin=1, gen_rects=False, size="auto"):
         """
         SVG of datamatrix.
 

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -68,7 +68,7 @@ class DataMatrix():
                     yield f"\n<rect width='2' height='2' x='{2*(j+margin)}' y='{2*(i+margin)}' fill='{fg}' />"
 
 
-    def svg(self, fg='#000', bg='#FFF', margin=1, size=None):
+    def svg(self, fg='#000', bg='#FFF', margin=1, render_size_mm=(12,12)):
         """
         SVG of datamatrix.
 
@@ -80,17 +80,15 @@ class DataMatrix():
         """
         
         rects = ''.join(self._svg_rect_iterator(fg,bg,margin))
-
-        mat = self.matrix
-        height = len(mat)
-        width = len(mat[0])
-        vbox_height = (height+margin*2)*2
-        vbox_width = (width+margin*2)*2
-        if size:
-            height = size[1]
-            width = size[0]
         
-        return svg_rects_template.format(fg=fg, bg=bg, rects=rects,
+        mat = self.matrix
+        vbox_height = len(mat)*(height+margin*2)*2
+        vbox_width = len(mat[0])*(width+margin*2)*2
+        height = render_size_mm[1]
+        width = render_size_mm[0]
+        
+        return svg_rects_template.format(fg=fg, bg=bg, 
+                                rects=rects,
                                 vbox_width = vbox_width,
                                 vbox_height = vbox_height,
                                 height=height, width=width)

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -86,8 +86,8 @@ class DataMatrix():
         width = len(mat[0])
         
         return svg_rects_template.format(fg=fg, bg=bg, rects=rects,
-                                vbox_width = (width+margin)*2,
-                                vbox_height = (height+margin)*2,
+                                vbox_width = (width+margin*2)*2,
+                                vbox_height = (height+margin*2)*2,
                                 height=2*height, width=2*width)
         
     @property

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -85,9 +85,9 @@ class DataMatrix():
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym:
-                    yield f"\n<rect width='1' height='1' x='{j}' y='{i}' fill='{fg}' stroke='{fg}' />"
+                    yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{fg}' stroke='{fg}' />"
                 else:
-                    yield f"\n<rect width='1' height='1' x='{j}' y='{i}' fill='{bg}' stroke='{bg}' />"
+                    yield f"\n<rect width='1' height='1' x='{j+1}' y='{i+1}' fill='{bg}' stroke='{bg}' />"
 
     def svg(self, fg='#000', bg='#FFF', margin=1):
         """

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -22,8 +22,8 @@ svg_rects_template = \
     'style="background-color:{bg}" ' \
     'xmlns="http://www.w3.org/2000/svg" ' \
     'xmlns:ev="http://www.w3.org/2001/xml-events" ' \
-    'xmlns:xlink="http://www.w3.org/1999/xlink"' \
-    'transform="scale({x_scale},{y_scale}) >' \
+    'xmlns:xlink="http://www.w3.org/1999/xlink" ' \
+    'transform="scale({x_scale},{y_scale})">' \
     '{rects}' \
     '</svg>'
 

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -85,9 +85,9 @@ class DataMatrix():
         for i,line in enumerate(mat):    
             for j,sym in enumerate(line):
                 if sym:
-                    yield f"<rect width=1 height=1 x={i+1} y={j+1} fill='{fg}' stroke='{fg}'>\n"
+                    yield f"<rect width=1 height=1 x='{i+1}' y='{j+1}' fill='{fg}' stroke='{fg}'>\n"
                 else:
-                    yield f"<rect width=1 height=1 x={i+1} y={j+1} fill='{bg}' stroke='{bg}'>\n"
+                    yield f"<rect width=1 height=1 x='{i+1}' y='{j+1}' fill='{bg}' stroke='{bg}'>\n"
 
     def svg(self, fg='#000', bg='#FFF', margin=1):
         """

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -82,8 +82,8 @@ class DataMatrix():
         rects = ''.join(self._svg_rect_iterator(fg,bg,margin))
         
         mat = self.matrix
-        vbox_height = len(mat)*(height+margin*2)*2
-        vbox_width = len(mat[0])*(width+margin*2)*2
+        vbox_height = (len(mat)+margin*2)*2
+        vbox_width = (len(mat[0])+margin*2)*2
         height = render_size_mm[1]
         width = render_size_mm[0]
         

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -17,12 +17,13 @@ from .utils import export
 svg_rects_template = \
     '<?xml version="1.0" encoding="utf-8" ?>' \
     '<svg baseProfile="tiny" version="1.2" ' \
-    'viewBox="{x0} {y0} {vbox_width} {vbox_height}" ' \
+    'viewBox="{x0} {y0} {width} {height}" ' \
     'width="{width}mm" height="{height}mm" ' \
     'style="background-color:{bg}" ' \
     'xmlns="http://www.w3.org/2000/svg" ' \
     'xmlns:ev="http://www.w3.org/2001/xml-events" ' \
-    'xmlns:xlink="http://www.w3.org/1999/xlink">' \
+    'xmlns:xlink="http://www.w3.org/1999/xlink"'
+    'transform="scale({x_scale,y_scale} >' \
     '{rects}' \
     '</svg>'
 
@@ -68,7 +69,7 @@ class DataMatrix():
                     yield f"\n<rect width='2' height='2' x='{2*j+1}' y='{2*i+1}' fill='{fg}' />"
 
 
-    def svg(self, fg='#000', bg='#FFF', margin=1, gen_rects=False, size="auto"):
+    def svg(self, fg='#000', bg='#FFF', margin=1, size=None):
         """
         SVG of datamatrix.
 
@@ -90,7 +91,7 @@ class DataMatrix():
 
         # margin is handled by adjusting the viewBox:
         vbox_height = height + margin * 2
-        vbox_width = height + margin * 2
+        vbox_width = width + margin * 2
         x0 -= margin
         y0 -= margin
 
@@ -98,13 +99,16 @@ class DataMatrix():
             height = vbox_height
             width = vbox_width
         else:
-            width = size[0]
-            height = size[1]
-            
+            output_width = size[0]
+            output_height = size[1]
+
+        x_scale = output_width / width.
+        y_scale = output_height / height.
+        
         return svg_rects_template.format(fg=fg, bg=bg, rects=rects,
                                 x0=x0, y0=y0, 
-                                vbox_height=2*vbox_height, vbox_width=2*width,
-                                height=height, width=width)
+                                height=2*height, width=2*width,
+                                x_scale=x_scale, y_scale=y_scale)
         
     @property
     def matrix(self):

--- a/src/ppf/datamatrix/datamatrix.py
+++ b/src/ppf/datamatrix/datamatrix.py
@@ -22,7 +22,7 @@ svg_rects_template = \
     'style="background-color:{bg}" ' \
     'xmlns="http://www.w3.org/2000/svg" ' \
     'xmlns:ev="http://www.w3.org/2001/xml-events" ' \
-    'xmlns:xlink="http://www.w3.org/1999/xlink"'
+    'xmlns:xlink="http://www.w3.org/1999/xlink"' \
     'transform="scale({x_scale,y_scale} >' \
     '{rects}' \
     '</svg>'


### PR DESCRIPTION
I'm trying to use this package to generate data matrix codes for use with lightburn for laser etching unique serial numbers.  The path-based approach to SVG generation does not work well in that particular software due to the need for closed paths, and I noticed a few other random incompatibilities when testing with editing software.   Although the line-path method is clearly valid SVG and an elegant way to represent a data matrix code, these difficulties limit its utility to me and probably others.

This PR offers code for two improvements for my particular use case:

1) Generates closed SVG <rect> elements instead of line paths.
 - a new generator is provided to output only the shaded rectangles to keep the size as small as possible
 - margins are handled slightly differently to permit for the second change below.

2) Add an argument to svg() method to permit the user to set a desired output size in mm's
 - Although SVG can of course be scaled easily in most SVG software, it's not convenient to need to scale every image when a standard display size is needed.
 - This allows software to import it at the intended size and go right to marking.
 - By default it creates 12mm x 12mm datamatrix codes.
 - Image corner is fixed at x=0,y=0, with margins added inside the quadrant instead of in the viewport.
 - Viewport is fixed to twice the size of code plus margins, then scaled with the viewBox to the desired mm's

The main down-side to this PR is that the SVG sizes are larger due to the <rect> elements as compared to line paths in the current development version, but compatibility is overall improved so I wanted to submit a PR even if you reject it, or wish to incorporate it in some other way.
